### PR TITLE
Allow possibility of duplicate schema names in datalink builder

### DIFF
--- a/python/lsst/sdm/tools/cli.py
+++ b/python/lsst/sdm/tools/cli.py
@@ -281,7 +281,10 @@ def compare_band_columns(
     if len(bands) == 0:
         raise click.BadParameter("At least one band must be specified")
     try:
-        schemas = _load_schemas(uris)
+        # We need to build the schemas without the mapping because this tool
+        # may encounter duplicate schema names, e.g., 'ivoa'.
+        schemas = [Schema.from_uri(uri, context={"id_generation": True}) for uri in uris]
+
         checker = SchemaBandColumnComparator(
             schemas,
             table_names,


### PR DESCRIPTION
Some duplicate schema names may be encountered like 'ivoa' so build the schemas without the mapping.

## Checklist

- [ ] Ran Jenkins
- [ ] Added a release note for user-visible changes to `docs/changes`
